### PR TITLE
fix: PERFIL na navbar + BoxDev padronizado

### DIFF
--- a/linikers/src/components/BoxDev.tsx
+++ b/linikers/src/components/BoxDev.tsx
@@ -1,7 +1,6 @@
 import { BugReport, DeveloperBoard, DesignServices } from "@mui/icons-material";
-import { Box, Grid2, Typography } from "@mui/material";
+import { Box, Typography, Card, CardContent } from "@mui/material";
 import { TbUxCircle } from "react-icons/tb";
-// import { DesignServices } from "@mui/icons-material";
 import { MdImportantDevices } from "react-icons/md";
 import { TbBugOff } from "react-icons/tb";
 
@@ -9,44 +8,74 @@ const UxIcon: any = TbUxCircle;
 const BugIcon: any = TbBugOff;
 const DeviceIcon: any = MdImportantDevices;
 
+interface DevItemProps {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+  color: string;
+}
+
+const items: DevItemProps[] = [
+  {
+    icon: <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}><UxIcon size={28} /><DesignServices fontSize="small" /></Box>,
+    title: "UX/UI Design",
+    desc: "Interfaces intuitivas, design systems, prototipagem, responsividade e experiencia do usuario.",
+    color: "#ec4899",
+  },
+  {
+    icon: <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}><DeveloperBoard fontSize="small" /><DeviceIcon size={28} /></Box>,
+    title: "Desenvolvimento",
+    desc: "Aplicacoes web completas, APIs, integracoes, deploy e monitoramento.",
+    color: "#22d3ee",
+  },
+  {
+    icon: <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}><BugReport fontSize="small" /><BugIcon size={28} /></Box>,
+    title: "Correcoes",
+    desc: "Debug, revisao de codigo, otimizacao de performance e resolucao de bugs.",
+    color: "#f59e0b",
+  },
+];
+
 export default function BoxDev() {
-  const iconSize = 40;
-  const gradientBackground = `radial-gradient(circle, rgba(150,150,150,2) 10%, rgba(245,245,220,4) 100%)`;
-
-  const cssBox = {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: "50%",
-    width: 120,
-    height: 120,
-    background: gradientBackground,
-  };
-
   return (
-    <Grid2 container spacing={4}>
-      <Box sx={cssBox}>
-        <Box display="flex">
-          <UxIcon size={iconSize} />
-          <DesignServices fontSize="large" />
-        </Box>
-        <Typography variant="subtitle1">UX/UI Design</Typography>
-      </Box>
-      <Box sx={cssBox}>
-        <Box display="flex">
-          <DeveloperBoard fontSize="large" />
-          <DeviceIcon size={iconSize} />
-        </Box>
-        <Typography variant="subtitle1">Desenvolvimento</Typography>
-      </Box>
-      <Box sx={cssBox}>
-        <Box display="flex">
-          <BugReport fontSize="large" />
-          <BugIcon size={iconSize} />
-        </Box>
-        <Typography variant="subtitle1">Correções</Typography>
-      </Box>
-    </Grid2>
+    <Box sx={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 3 }}>
+      {items.map((item) => (
+        <Card
+          key={item.title}
+          sx={{
+            width: 220,
+            background: "rgba(255,255,255,0.02)",
+            backdropFilter: "blur(8px)",
+            border: "1px solid",
+            borderColor: "divider",
+            borderRadius: 3,
+            transition: "all 0.25s",
+            "&:hover": {
+              borderColor: item.color,
+              transform: "translateY(-2px)",
+              boxShadow: `0 4px 20px ${item.color}10`,
+            },
+          }}
+        >
+          <CardContent sx={{ p: 3, textAlign: "center" }}>
+            <Box sx={{ color: item.color, mb: 1.5, display: "flex", justifyContent: "center" }}>
+              {item.icon}
+            </Box>
+            <Typography
+              variant="h6"
+              sx={{ fontFamily: "monospace", fontWeight: 700, fontSize: "0.9rem", mb: 1 }}
+            >
+              {item.title}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ color: "text.secondary", fontSize: "0.8rem", lineHeight: 1.6 }}
+            >
+              {item.desc}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
   );
 }

--- a/linikers/src/components/Navbar.tsx
+++ b/linikers/src/components/Navbar.tsx
@@ -16,6 +16,7 @@ const navLinks = [
   { href: "/projetos", label: "PROJETOS" },
   { href: "/ferramentas", label: "FERRAMENTAS" },
   { href: "/criativo", label: "CRIATIVO" },
+  { href: "/perfil", label: "PERFIL" },
   { href: "/blog", label: "BLOG" },
   { href: "/contato", label: "CONTATO" },
 ];


### PR DESCRIPTION
## O que mudou

### Navbar — [PERFIL] adicionado
Antes: HOME · PROJETOS · FERRAMENTAS · CRIATIVO · BLOG · CONTATO
Depois: HOME · PROJETOS · FERRAMENTAS · CRIATIVO · PERFIL · BLOG · CONTATO

### BoxDev (ferramentas) — Padronizado
Antes: 3 bolinhas cinza claro 120x120px destoando do layout escuro
Depois: Cards no mesmo padrao do site (monospace, hover effects)

### Contato
Application Error nao reproduziu - possivel erro transiente de deploy.