### PR TITLE
fix: busca prospeccao city-only + pagina /admin

### DIFF
--- a/linikers/src/pages/admin/index.tsx
+++ b/linikers/src/pages/admin/index.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Box, Container, Typography, Paper, Grid } from "@mui/material";
+import {
+  Dashboard as DashboardIcon,
+  Store as StoreIcon,
+  Terminal as TerminalIcon,
+  Campaign as CampaignIcon,
+  Groups as GroupsIcon,
+} from "@mui/icons-material";
+import Link from "next/link";
+
+const modules = [
+  { href: "/admin/dashboard", label: "Dashboard", icon: <DashboardIcon />, desc: "Métricas e visão geral" },
+  { href: "/admin/ml", label: "Mercado Livre", icon: <StoreIcon />, desc: "Campanhas e vendas ML" },
+  { href: "/admin/gerador", label: "Gerador de Conteúdo", icon: <TerminalIcon />, desc: "IA para criar posts" },
+  { href: "/admin/propaganda", label: "Propagandas", icon: <CampaignIcon />, desc: "Gerenciar anúncios" },
+  { href: "/admin/prospect", label: "Prospecção", icon: <GroupsIcon />, desc: "Leads e captação" },
+];
+
+export default function AdminIndex() {
+  return (
+    <Box sx={{ minHeight: "100vh", background: "#0a0a0f", py: 6 }}>
+      <Container maxWidth="lg">
+        <Typography variant="h4" sx={{ fontWeight: 800, color: "#fff", mb: 1 }}>
+          Painel Administrativo
+        </Typography>
+        <Typography sx={{ color: "#64748b", mb: 4 }}>
+          Gerencie suas ferramentas e integrações.
+        </Typography>
+
+        <Grid container spacing={3}>
+          {modules.map((m) => (
+            <Grid item xs={12} sm={6} md={4} key={m.href}>
+              <Link href={m.href} passHref legacyBehavior>
+                <Paper
+                  component="a"
+                  sx={{
+                    p: 3,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1.5,
+                    background: "rgba(255,255,255,0.03)",
+                    border: "1px solid rgba(255,255,255,0.08)",
+                    borderRadius: 3,
+                    cursor: "pointer",
+                    textDecoration: "none",
+                    transition: "0.2s",
+                    "&:hover": { borderColor: "rgba(99,102,241,0.4)", transform: "translateY(-2px)" },
+                  }}
+                >
+                  <Box sx={{ color: "#818cf8", fontSize: "2rem" }}>{m.icon}</Box>
+                  <Typography sx={{ color: "#e2e8f0", fontWeight: 700 }}>{m.label}</Typography>
+                  <Typography sx={{ color: "#64748b", fontSize: "0.85rem", textAlign: "center" }}>{m.desc}</Typography>
+                </Paper>
+              </Link>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </Box>
+  );
+}

--- a/linikers/src/pages/api/prospects/search.ts
+++ b/linikers/src/pages/api/prospects/search.ts
@@ -15,64 +15,115 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     let businesses: any[] = [];
 
     if (lat && lon) {
-      // Busca por localizacao (coordenadas) - mais precisa
+      // Busca por coordenadas - Overpass direto
       const overpassQuery = `
-        [out:json][timeout:15];
+        [out:json][timeout:20];
         (
           node["shop"](around:${radius},${lat},${lon});
-          node["office"](around:${radius},${lat},${lon});
           node["craft"](around:${radius},${lat},${lon});
+          node["office"](around:${radius},${lat},${lon});
           node["amenity"](around:${radius},${lat},${lon});
           way["shop"](around:${radius},${lat},${lon});
-          way["office"](around:${radius},${lat},${lon});
           way["craft"](around:${radius},${lat},${lon});
+          way["office"](around:${radius},${lat},${lon});
+          way["amenity"](around:${radius},${lat},${lon});
         );
         out body;
         out center;
       `;
 
-      const osmRes = await fetch(OSM_OVERPASS, {
+      const res2 = await fetch(OSM_OVERPASS, {
         method: "POST",
         body: `data=${encodeURIComponent(overpassQuery)}`,
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       });
+      if (!res2.ok) throw new Error("OSM error");
 
-      if (!osmRes.ok) throw new Error("OSM error");
-      const osmData = await osmRes.json();
-
-      businesses = (osmData.elements || []).map((el: any) => ({
+      const data = await res2.json();
+      businesses = (data.elements || []).map((el: any) => ({
         id: `osm_${el.type}_${el.id}`,
-        name: el.tags?.name || el.tags?.operator || "Sem nome",
-        address: [
-          el.tags?.["addr:street"],
-          el.tags?.["addr:housenumber"],
-          el.tags?.["addr:city"],
-        ].filter(Boolean).join(", ") || "",
+        name: el.tags?.name || el.tags?.operator || el.tags?.brand || "Sem nome",
+        address: [el.tags?.["addr:street"], el.tags?.["addr:housenumber"], el.tags?.["addr:city"]].filter(Boolean).join(", ") || "",
         phone: el.tags?.phone || el.tags?.["contact:phone"] || "",
         website: el.tags?.website || el.tags?.["contact:website"] || "",
-        category: el.tags?.shop || el.tags?.office || el.tags?.craft || el.tags?.amenity || "",
+        category: el.tags?.shop || el.tags?.craft || el.tags?.office || el.tags?.amenity || "",
         lat: el.lat || el.center?.lat,
         lon: el.lon || el.center?.lon,
       }));
 
     } else if (q) {
-      // Busca por texto (endereco + tipo de negocio)
-      const geoRes = await fetch(
-        `${OSM_SEARCH}?q=${encodeURIComponent(q as string)}&format=json&limit=10&addressdetails=1`,
+      const queryStr = typeof q === "string" ? q : String(q);
+
+      // Extrai possivel cidade do query (geralmente ultima palavra)
+      const parts = queryStr.trim().split(/\s+/);
+      const cidadeCandidate = parts[parts.length - 1];
+
+      // Tenta geocode só a cidade (prioriza resultado do tipo city/town)
+      let geoRes = await fetch(
+        `${OSM_SEARCH}?q=${encodeURIComponent(cidadeCandidate)}&format=json&limit=10&countrycodes=br`,
         { headers: { "User-Agent": "LinikersPortfolio/1.0" } }
       );
       if (!geoRes.ok) throw new Error("Geo error");
-      const geoData = await geoRes.json();
+      let geoData = await geoRes.json();
 
-      businesses = geoData.map((el: any) => ({
-        id: `geo_${el.osm_type}_${el.osm_id}`,
-        name: el.display_name?.split(",")[0] || el.name || "Sem nome",
-        address: el.display_name || "",
-        phone: el.address?.phone || "",
-        category: el.type || el.category || "",
-        lat: el.lat,
-        lon: el.lon,
-      }));
+      // Filtra APENAS resultados do tipo city/town/village — nada de estabelecimentos
+      let loc = geoData.find((r: any) => ["city", "town", "village", "municipality"].includes(r.type));
+
+      // Se nao achou, tenta o query completo com mesmo filtro
+      if (!loc) {
+        geoRes = await fetch(
+          `${OSM_SEARCH}?q=${encodeURIComponent(queryStr)}&format=json&limit=10&countrycodes=br`,
+          { headers: { "User-Agent": "LinikersPortfolio/1.0" } }
+        );
+        if (!geoRes.ok) throw new Error("Geo error");
+        geoData = await geoRes.json();
+        loc = geoData.find((r: any) => ["city", "town", "village", "municipality"].includes(r.type));
+      }
+
+      if (loc) {
+        const centerLat = loc.lat;
+        const centerLon = loc.lon;
+
+        // Passo 2: Busca negocios perto dessa localizacao via Overpass
+        const overpassQuery = `
+          [out:json][timeout:25];
+          (
+            node["shop"](around:${radius},${centerLat},${centerLon});
+            node["craft"](around:${radius},${centerLat},${centerLon});
+            node["office"](around:${radius},${centerLat},${centerLon});
+            node["amenity"](around:${radius},${centerLat},${centerLon});
+            way["shop"](around:${radius},${centerLat},${centerLon});
+            way["craft"](around:${radius},${centerLat},${centerLon});
+            way["office"](around:${radius},${centerLat},${centerLon});
+            way["amenity"](around:${radius},${centerLat},${centerLon});
+          );
+          out body;
+          out center;
+        `;
+
+        const osmRes = await fetch(OSM_OVERPASS, {
+          method: "POST",
+          body: `data=${encodeURIComponent(overpassQuery)}`,
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        });
+
+        if (!osmRes.ok) throw new Error("OSM error");
+        const osmData = await osmRes.json();
+
+        businesses = (osmData.elements || [])
+          .filter((el: any) => el.tags?.name) // So com nome
+          .map((el: any) => ({
+            id: `osm_${el.type}_${el.id}`,
+            name: el.tags?.name || el.tags?.operator || el.tags?.brand || "Sem nome",
+            address: [el.tags?.["addr:street"], el.tags?.["addr:housenumber"], el.tags?.["addr:city"]].filter(Boolean).join(", ") || "",
+            phone: el.tags?.phone || el.tags?.["contact:phone"] || "",
+            website: el.tags?.website || el.tags?.["contact:website"] || "",
+            category: el.tags?.shop || el.tags?.craft || el.tags?.office || el.tags?.amenity || "",
+            lat: el.lat || el.center?.lat,
+            lon: el.lon || el.center?.lon,
+          }))
+          .slice(0, 30); // Limita a 30 resultados
+      }
     }
 
     return res.status(200).json({ businesses, count: businesses.length });

--- a/linikers/src/pages/api/prospects/search.ts
+++ b/linikers/src/pages/api/prospects/search.ts
@@ -67,7 +67,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       let geoData = await geoRes.json();
 
       // Filtra APENAS resultados do tipo city/town/village — nada de estabelecimentos
-      let loc = geoData.find((r: any) => ["city", "town", "village", "municipality"].includes(r.type));
+      // Usa addresstype (ex: "municipality") com fallback pra type (ex: "administrative")
+      const isCity = (r: any) => ["city","town","village","municipality","administrative"].includes(r.addresstype || r.type);
+      let loc = geoData.find(isCity);
 
       // Se nao achou, tenta o query completo com mesmo filtro
       if (!loc) {
@@ -77,7 +79,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         );
         if (!geoRes.ok) throw new Error("Geo error");
         geoData = await geoRes.json();
-        loc = geoData.find((r: any) => ["city", "town", "village", "municipality"].includes(r.type));
+        loc = geoData.find(isCity);
       }
 
       if (loc) {


### PR DESCRIPTION
## Correcoes pos-merge PR #38

### O que mudou
1. **/api/prospects/search.ts** — busca agora filtra resultados do Nominatim para ONLY city/town/village. Antes pegava o primeiro resultado qualquer (podia ser um estabelecimento em outra cidade). Agora so acha cidades de verdade.
2. **/pages/admin/index.tsx** — pagina inicial /admin com cards de navegacao (Dashboard, ML, Gerador, Propaganda, Prospeccao)
3. Countrycodes BR adicionado ao Nominatim
4. Extrai cidade do query antes de buscar

### Build
npx tsc --noEmit OK