### PR TITLE
feat: SEO completo — meta tags, sitemap, headings semânticos

### DIFF
--- a/linikers/next-sitemap.config.js
+++ b/linikers/next-sitemap.config.js
@@ -1,0 +1,17 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: "https://linikers.cloud",
+  generateRobotsTxt: true,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin", "/api"],
+      },
+    ],
+  },
+  exclude: ["/admin/**", "/api/**", "/login", "/whatsapp-qr"],
+  generateIndexSitemap: false,
+  outDir: "public",
+};

--- a/linikers/package.json
+++ b/linikers/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postbuild": "next-sitemap --config next-sitemap.config.js"
   },
   "dependencies": {
     "@emotion/react": "^11.13.3",

--- a/linikers/src/components/SEO.tsx
+++ b/linikers/src/components/SEO.tsx
@@ -1,0 +1,53 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+
+interface SEOProps {
+  title: string;
+  description: string;
+  canonical?: string;
+  ogImage?: string;
+  ogType?: "website" | "article";
+  noindex?: boolean;
+}
+
+const SITE = "https://linikers.cloud";
+const DEFAULT_IMG = "/profileImg.jpg";
+
+export default function SEO({
+  title,
+  description,
+  canonical,
+  ogImage = DEFAULT_IMG,
+  ogType = "website",
+  noindex,
+}: SEOProps) {
+  const router = useRouter();
+  const url = canonical || `${SITE}${router.asPath}`;
+  const fullTitle = `${title} | LinikerS`;
+
+  return (
+    <Head>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+
+      {/* Open Graph */}
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={`${SITE}${ogImage}`} />
+      <meta property="og:type" content={ogType} />
+      <meta property="og:site_name" content="LinikerS" />
+      <meta property="og:locale" content="pt_BR" />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={`${SITE}${ogImage}`} />
+
+      {/* No index */}
+      {noindex && <meta name="robots" content="noindex" />}
+    </Head>
+  );
+}

--- a/linikers/src/pages/404.tsx
+++ b/linikers/src/pages/404.tsx
@@ -1,10 +1,15 @@
+import SEO from "@/components/SEO";
+
 export default function NotFound() {
     return (
-        <div className="flex items-center justify-center h-screen">
+        <>
+            <SEO title="Página não encontrada" description="404 — A página que você procura não existe." noindex />
+            <div className="flex items-center justify-center h-screen">
             <div className="text-center">
                 <h1 className="text-4xl font-bold mb-4">404 - Página não encontrada</h1>
                 <p className="text-gray-400">A página que você está procurando não existe.</p>
             </div>
         </div>
+        </>
     );
 }

--- a/linikers/src/pages/_app.tsx
+++ b/linikers/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import Tooltip from "@mui/material/Tooltip";
 import PaletteIcon from "@mui/icons-material/Palette";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import Head from "next/head";
 import "@/styles/globals.scss";
 
 const themes = [
@@ -70,7 +71,15 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const theme = buildTheme(themeMeta);
 
   return (
-    <MuiThemeProvider theme={theme}>
+    <>
+      <Head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#0a0a0a" />
+        <link rel="icon" href="/favicon.png" />
+        <meta name="google-site-verification" content="f3b6fe1ad59f5971" />
+      </Head>
+      <MuiThemeProvider theme={theme}>
       <CssBaseline />
       <Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
         <Navbar />
@@ -98,5 +107,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         </IconButton>
       </Tooltip>
     </MuiThemeProvider>
+    </>
   );
 }

--- a/linikers/src/pages/blog.tsx
+++ b/linikers/src/pages/blog.tsx
@@ -1,4 +1,5 @@
 import { Container, Typography, Box } from "@mui/material";
+import SEO from "@/components/SEO";
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
@@ -7,7 +8,12 @@ import html from "remark-html";
 
 export default function Blog({ posts }: any) {
   return (
-    <Container maxWidth="md" sx={{ py: 6 }}>
+    <>
+      <SEO
+        title="Blog"
+        description="Artigos sobre tecnologia, desenvolvimento web, Next.js, React, TypeScript, Web3 e automação. Por LinikerS."
+      />
+      <Container maxWidth="md" sx={{ py: 6 }}>
       <Typography
         variant="h2"
         sx={{
@@ -73,9 +79,9 @@ export default function Blog({ posts }: any) {
         </Typography>
       )}
     </Container>
+    </>
   );
 }
-
 export async function getStaticProps() {
   try {
     const markdownFilePath = path.join(process.cwd(), "iniBlog.md");

--- a/linikers/src/pages/contato.tsx
+++ b/linikers/src/pages/contato.tsx
@@ -1,5 +1,6 @@
 import { Container, Typography, Box, IconButton, Stack } from "@mui/material";
 import { WhatsApp } from "@mui/icons-material";
+import SEO from "@/components/SEO";
 import { FaGithub, FaLinkedin, FaXTwitter, FaInstagram } from "react-icons/fa6";
 import { motion } from "framer-motion";
 import Image from "next/image";
@@ -18,7 +19,12 @@ const socials = [
 
 export default function Contato() {
   return (
-    <Container
+    <>
+      <SEO
+        title="Contato"
+        description="Entre em contato com LinikerS para orçamentos de sites, landing pages, sistemas web, bots e automação. Respondo em até 24h."
+      />
+      <Container
       maxWidth="sm"
       sx={{
         minHeight: "80vh",
@@ -119,5 +125,6 @@ export default function Contato() {
         ▸ response.time: ~24h
       </Typography>
     </Container>
+    </>
   );
 }

--- a/linikers/src/pages/index.tsx
+++ b/linikers/src/pages/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import SEO from "@/components/SEO";
 import {
   Box,
   Container,
@@ -175,6 +176,12 @@ export default function Home() {
 
   // ─── LANDING PHASE ─────────────────────────
   return (
+    <>
+      <SEO
+        title="Desenvolvedor Full Stack"
+        description="Criação de sites, landing pages, sistemas web, bots e automação. Next.js, React, TypeScript, Web3. LinikerS — soluções inteligentes para seu negócio."
+        ogImage="/profileImg.jpg"
+      />
       <MotionBox
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -232,7 +239,7 @@ export default function Home() {
 
                 <motion.div variants={itemVariants}>
                   <Typography
-                    variant="h2"
+                    variant="h1"
                     sx={{
                       fontWeight: 900,
                       fontSize: { xs: "2.5rem", md: "3.75rem" },
@@ -442,5 +449,6 @@ export default function Home() {
           </motion.div>
         </Container>
       </MotionBox>
+    </>
   );
 }

--- a/linikers/src/pages/portfolio.tsx
+++ b/linikers/src/pages/portfolio.tsx
@@ -1,5 +1,6 @@
 // Pagina publica de portfolio para leads/prospects
 import { Box, Container, Typography, Paper, Grid, Chip, Button, Avatar } from "@mui/material";
+import SEO from "@/components/SEO";
 import {
   Code as CodeIcon,
   Web as WebIcon,
@@ -45,7 +46,12 @@ export default function PortfolioPage() {
   const { ref } = router.query;
 
   return (
-    <Box sx={{ minHeight: "100vh", background: "#0a0a0f", py: 6 }}>
+    <>
+      <SEO
+        title="Portfólio"
+        description="Portfólio de Liniker Souza — Desenvolvedor Full Stack especializado em Next.js, React, Node, TypeScript e Web3. Projetos, cases e contato."
+      />
+      <Box sx={{ minHeight: "100vh", background: "#0a0a0f", py: 6 }}>
       <Container maxWidth="lg">
         {/* Header */}
         <Box sx={{ textAlign: "center", mb: 6 }}>
@@ -142,5 +148,6 @@ export default function PortfolioPage() {
         </Paper>
       </Container>
     </Box>
+    </>
   );
 }

--- a/linikers/src/pages/projetos.tsx
+++ b/linikers/src/pages/projetos.tsx
@@ -1,4 +1,5 @@
 import { Container, Typography, Box, Grid2, Chip, Stack } from "@mui/material";
+import SEO from "@/components/SEO";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import CardContent from "@mui/material/CardContent";
@@ -58,7 +59,12 @@ const anteriores = [
 
 export default function Projetos() {
   return (
-    <Container maxWidth="lg" sx={{ py: 6 }}>
+    <>
+      <SEO
+        title="Projetos"
+        description="Portfólio de projetos de desenvolvimento: polyLink, CarCrew Commerce, ERC20 Token Lab, Taiff Connect e mais. Soluções em Next.js, React, Web3."
+      />
+      <Container maxWidth="lg" sx={{ py: 8 }}>
       {/* ─── Header ─────────────────────────── */}
       <Typography
         variant="h2"
@@ -264,5 +270,6 @@ export default function Projetos() {
         ))}
       </Grid2>
     </Container>
+    </>
   );
 }


### PR DESCRIPTION
- SEO.tsx: componente reutilizável com Open Graph, Twitter Cards, canonical
- next-sitemap.config.js: gera sitemap.xml + robots.txt automático no build
- _app.tsx: charset, viewport, favicon, theme-color, verificação GSC
- index.tsx: title/description OG + h1 semântico no lugar de h2
- blog.tsx, projetos.tsx, contato.tsx, portfolio.tsx: meta tags específicas
- 404.tsx: noindex para página de erro
- package.json: postbuild para gerar sitemap após o build